### PR TITLE
Don't use macro to access the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Let's take our book example from above:
 plug LoadResource.Plug, [model: Book, not_found: &MyErrorHandler.not_found/1]
 ```
 
-Bam! That's all you need. If the `id` param of the incoming request matches a book in the `books` table, it will be available to your controller as `conn.assigns[:book]`; if not, it'll halt the request and pass `conn` over to your error handler to customize the error response.
+Bam! That's all you need. If the `id` param of the incoming request matches a book in the `books` table, it will be available to your controller as `conn.assigns[:book]`; if not, it'll halt the request and pass `conn` over to your error handler to customize the error response. (Note: the handler method can't be private, since it's called by LoadResource.)
 
 ### Nested Resources
 

--- a/lib/load_resource/plug.ex
+++ b/lib/load_resource/plug.ex
@@ -66,9 +66,7 @@ defmodule LoadResource.Plug do
     }
     scopes = options[:scopes] || []
 
-    query = LoadResource.QueryBuilder.build(model, conn, [id_scope] ++ scopes)
-
-    query
+    LoadResource.QueryBuilder.build(model, conn, [id_scope] ++ scopes)
     |> repo().one
     |> handle_resource(conn, options)
   end

--- a/lib/load_resource/plug.ex
+++ b/lib/load_resource/plug.ex
@@ -7,19 +7,19 @@ defmodule LoadResource.Plug do
   Load a Book resource using the `id` param on the incoming request:
 
   ```
-  plug LoadResource.Plug, [model: Book, not_found: &MyErrorHandler.not_found/1]
+  plug LoadResource.Plug, [model: Book, handler: &MyErrorHandler.not_found/1]
   ```
 
   Use the `book_id` param instead of `id` (useful when composing multiple resources):
 
   ```
-  plug LoadResource.Plug, [model: Book, id_key: "book_id", not_found: &MyErrorHandler.not_found/1]
+  plug LoadResource.Plug, [model: Book, id_key: "book_id", handler: &MyErrorHandler.not_found/1]
   ```
 
   Load a Quote that matches to a previously loaded Book:
 
   ```
-  plug LoadResource.Plug, [model: Quote, scopes: [:book], not_found: &MyErrorHandler.not_found/1]
+  plug LoadResource.Plug, [model: Quote, scopes: [:book], handler: &MyErrorHandler.not_found/1]
   ```
 
   (See `LoadResource.Scope` for more information on scopes.)
@@ -27,7 +27,7 @@ defmodule LoadResource.Plug do
   ## Accepted Options
 
   * `model`: an Ecto model representing the resource you want to load (required)
-  * `not_found`: a function/1 that gets called if the record can't be found and `required: true` (required)
+  * `handler`: a function/1 that gets called if the record can't be found and `required: true` (required)
   * `id_key`: what param in the incoming request represents the ID of the record (optional, default: "id")
   * `required`: whether to halt the plug pipeline and return an error response if the record can't be found (optional, default: true)
   * `scopes`: an list of atoms and/or `LoadResource.Scope` structs (optional, default: [])
@@ -36,8 +36,6 @@ defmodule LoadResource.Plug do
   import Plug.Conn
 
   alias LoadResource.Scope
-
-  @repo Application.get_env(:load_resource, :repo)
 
   @doc """
   Initialize the plug with any options provided in the controller or pipeline, including calculating the resource_name (which key will written to in `conn.assigns`) from the model.
@@ -71,7 +69,7 @@ defmodule LoadResource.Plug do
     query = LoadResource.QueryBuilder.build(model, conn, [id_scope] ++ scopes)
 
     query
-    |> @repo.one
+    |> repo().one
     |> handle_resource(conn, options)
   end
 
@@ -88,4 +86,9 @@ defmodule LoadResource.Plug do
   defp handle_resource(resource, conn, %{resource_name: resource_name}) do
     assign(conn, resource_name, resource)
   end
+
+  defp repo() do
+    Application.get_env(:load_resource, :repo)
+  end
+
 end


### PR DESCRIPTION
The way Elixir handles environment itvalues and macros is, frankly, confusing. Some things work all the time, others have to be known at compile time, and it's not clear which category the values set in config.exs belong to.

This PR works around that by no longer accessing the repo via a macro but rather via a regular method.