### PR TITLE
Use proper scope data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,5 @@
+0.3.0
+=======
+
+* [Fix] Scope.from_atom stores a scope_key atom rather than an anonymous function to avoid Elixir
+  serialization issues

--- a/lib/load_resource/scope.ex
+++ b/lib/load_resource/scope.ex
@@ -66,12 +66,12 @@ defmodule LoadResource.Scope do
   `Scope.evaluate(scope)` will return "foo".
   ```
   """
-  def evaluate(%Scope{scope_key: scope_key}, conn) do
-    process_scope_value(conn.assigns[scope_key])
-  end
-
   def evaluate(%Scope{value: value}, conn) when is_function(value, 1) do
     process_scope_value(value.(conn))
+  end
+
+  def evaluate(%Scope{scope_key: scope_key}, conn) when is_atom(scope_key) do
+    process_scope_value(conn.assigns[scope_key])
   end
 
   defp process_scope_value(value) when is_atom(value), do: value

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LoadResource.Mixfile do
   def project do
     [
       app: :load_resource,
-      version: "0.2.0",
+      version: "0.3.0",
       elixir: "~> 1.0",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/test/load_resource/query_builder_test.exs
+++ b/test/load_resource/query_builder_test.exs
@@ -9,6 +9,10 @@ defmodule LoadResource.QueryBuilderTest do
   import Ecto.Query
   import TestHelper
 
+  def scope_test(conn) do
+    conn.params[:book_type]
+  end
+
   describe "build" do
     test "will add an atom scope" do
       scope = :book
@@ -18,8 +22,8 @@ defmodule LoadResource.QueryBuilderTest do
       assert_query_equality(QueryBuilder.build(TestModel, conn, [scope]), expected_query)
     end
 
-    test "will layer multiple scopes" do
-      scope = %Scope{column: :book_type, value: fn(conn) -> conn.params[:book_type] end}
+    test "will support complex scopes" do
+      scope = %Scope{column: :book_type, value: &LoadResource.QueryBuilderTest.scope_test/1}
       conn = %{params: %{book_type: "novel"}}
 
       expected_query = from row in TestModel, where: ^[{:book_type, "novel"}]
@@ -28,7 +32,7 @@ defmodule LoadResource.QueryBuilderTest do
 
     test "layers multiple queries together" do
       scope = :book
-      second_scope = %Scope{column: :book_type, value: fn(conn) -> conn.params[:book_type] end}
+      second_scope = %Scope{column: :book_type, value: &LoadResource.QueryBuilderTest.scope_test/1}
       conn = %{assigns: %{book: %{id: 1234}}, params: %{book_type: "novel"}}
 
       expected_query = from row in TestModel, where: ^[{:book_id, 1234}], where: ^[{:book_type, "novel"}]

--- a/test/load_resource/scope_test.exs
+++ b/test/load_resource/scope_test.exs
@@ -20,7 +20,7 @@ defmodule LoadResource.ScopeTest do
       conn = %{assigns: %{book: book}}
 
       scope = Scope.from_atom(:book)
-      assert scope.value.(conn) == book
+      assert scope.scope_key == :book
     end
   end
 


### PR DESCRIPTION
Turns out that you can't use anonymous functions as values for structs in Elixir if you're doing anything interesting with them, such as using them to define plug behavior. (If you do, you get an error like `elixir cannot escape #Function<0.9159482/1 in :elixir_compiler_1.__MODULE__/1>. The supported values are: lists, tuples, maps, atoms, numbers, bitstrings, PIDs and remote functions in the format &Mod.fun/arity`.)

This PR rewrites `Scope.from_atom` to store a `scope_key` atom, which is processes automatically when evaluating the scope. It's not quite as elegant, but it works.