### PR TITLE
Allow users to specify the resource_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ LoadResource makes that easy for Phoenix apps and any other Elixir projects usin
 * Lightweight: no dependencies beyond Ecto
 * Flexible: straightforward options make it easy to handle many common cases
 * Tested: fully tested in ExUnit and linted by [Credo](https://github.com/rrrene/credo)
-* Documented: [fully documented on hex.pm](https://hexdocs.pm/load_resource/0.1.0)
+* Documented: [fully documented on hex.pm](https://hexdocs.pm/load_resource/0.4.0)
 
 Feedback or pull requests for additional configuration very welcome! See below.
 
@@ -109,6 +109,8 @@ LoadResource.Plug takes the following options:
 * `not_found`: a function/1 that gets called if the record can't be found and `required: true` (required)
 * `id_key`: what param in the incoming request represents the ID of the record (optional, default: "id")
 * `required`: whether to halt the plug pipeline and return an error response if the record can't be found (optional, default: true)
+* `resource_name`: under what value to store the resource in `conn.assigns` (optional, default:
+  derived from the model)
 * `scopes`: an list of` :atom`s and/or `Scope`s as described above (optional, default: [])
 
 ## Known Limitations

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+0.4.0
+======
+
+* [New feature] The :resource_name key can be specified to control the key a resource is assigned
+  to in conn.assigns.
+
 0.3.0
 =======
 

--- a/lib/load_resource/plug.ex
+++ b/lib/load_resource/plug.ex
@@ -49,7 +49,7 @@ defmodule LoadResource.Plug do
     # It's safe to use Macro.underscore here because we know the text only contains characters
     # valid for Elixir identifiers. (See https://hexdocs.pm/elixir/Macro.html#underscore/1.)
     model = Map.fetch!(options, :model)
-    resource_name = String.to_atom(Macro.underscore(List.last(String.split(to_string(model), "."))))
+    resource_name = options[:resource_name] || String.to_atom(Macro.underscore(List.last(String.split(to_string(model), "."))))
 
     Map.put(options, :resource_name, resource_name)
   end
@@ -82,6 +82,7 @@ defmodule LoadResource.Plug do
   end
 
   defp handle_resource(resource, conn, %{resource_name: resource_name}) do
+    IO.puts "Assigning #{resource_name} #{resource.id}"
     assign(conn, resource_name, resource)
   end
 

--- a/lib/load_resource/plug.ex
+++ b/lib/load_resource/plug.ex
@@ -30,6 +30,7 @@ defmodule LoadResource.Plug do
   * `handler`: a function/1 that gets called if the record can't be found and `required: true` (required)
   * `id_key`: what param in the incoming request represents the ID of the record (optional, default: "id")
   * `required`: whether to halt the plug pipeline and return an error response if the record can't be found (optional, default: true)
+  * `resource_name`: under what value to store the resource in `conn.assigns` (optional, default: derived from the model)
   * `scopes`: an list of atoms and/or `LoadResource.Scope` structs (optional, default: [])
   """
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LoadResource.Mixfile do
   def project do
     [
       app: :load_resource,
-      version: "0.3.0",
+      version: "0.4.0",
       elixir: "~> 1.0",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/test/load_resource/plug_test.exs
+++ b/test/load_resource/plug_test.exs
@@ -27,6 +27,16 @@ defmodule LoadResource.PlugTest do
       }
     end
 
+    test "allows you to override the resource_name" do
+      opts = LoadResource.Plug.init(@default_opts ++ [resource_name: "foobar"])
+      assert opts == %{
+        model: TestModel,
+        resource_name: "foobar",
+        handler: &TestErrorHandler.not_found/1,
+        required: true
+      }
+    end
+
     test "it raises an error if model isn't provided" do
       assert_raise KeyError, fn ->
         LoadResource.Plug.init([])


### PR DESCRIPTION
If you want to load two different resources with the same model (for instance, when doing a sequencing operation requiring two of the same record), the `resource_name` field would be the same and the first resource would be clobbered by the second. This PR allows users to set the `resource_name` via an option so that `load_resource` can be used in cases like these.